### PR TITLE
add more options to include script

### DIFF
--- a/src/templates/_head_includes.jade
+++ b/src/templates/_head_includes.jade
@@ -12,15 +12,15 @@ if SITE.tokens.crisp_website_id
 
     (function(){d=document;s=d.createElement("script");s.src="#{crisp_chatbox_url}";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();
 
+each script_url in SITE.includes.scripts.urls
+  if script_url.url
+    script(src=script_url.url, defer=script_url.defer)
+  else
+    script(src="#{script_url}",defer)
+
 each script_inline in SITE.includes.scripts.inline
   script.
     #{script_inline}
-
-each script_url in SITE.includes.scripts.urls
-  script(
-    src="#{script_url}",
-    defer
-  )
 
 each stylesheet_inline in SITE.includes.stylesheets.inline
   style.


### PR DESCRIPTION
Hey, the following use-case was needed for my personal use:
1. Use an external script
2. Initialize it with some values. 

The existing option is only to create a deferrable script tag. and one more thing, the inline script was rendered before the script tag, for example:
this config
```
...
    "scripts" : {
      "urls"   : ["some link"],
      "inline" : ["init({someArgs})"]
    },
...
```


will result:

```
....
    <script>
      init({someArgs})
    </script>
    <script src="some link" defer></script>
...
```

In my case, the order of the script tag and inline script is reversed. moreover, you can also create a non deferable script tag like so:
```
...
    "scripts" : {
      "urls"   : [{"url": "https://somescript/index.js", "defer": false}],
      "inline" : []
    },
...
```
IDK how needed it is, but it helped me :)