### PR TITLE
feat!: Fix heading ID discrepancy between sidebar and article

### DIFF
--- a/res/plugins/gulp/pug-templates.js
+++ b/res/plugins/gulp/pug-templates.js
@@ -719,7 +719,7 @@ module.exports = {
         // Start a new current entry?
         if (_item !== null) {
           _current_entry = {
-            id       : _item.slug,
+            id       : slug(_item.content),
             title    : _item.content,
             subtrees : []
           };


### PR DESCRIPTION
This fixes incorrect IDs in the sidebar when a heading contains an underscore (`_`).

For example, “## branding.api_app_name” gets rendered as

```html
<h2 id="brandingapiappname"><a class="title-anchor" href="#brandingapiappname">branding.api_app_name</a></h2>
```

in the page, but was rendered as

```html
<a href="#brandingapi_app_name" data-anchor="#brandingapi_app_name" class="nest-navigate-link" data-cshid="98e0cf7f-7cea-a908-2452-f43b1fa1729c"><span class="nest-navigate-link-text">branding.api_app_name</span></a>
```

in the sidebar.

This meant the sidebar was broken, because it pointed to an inexistent ID.